### PR TITLE
Added DetectionInterfaceList type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
         "msg/DetectionInterface/Types/PedIsle.msg"
         "msg/DetectionInterface/Types/Pedestrian.msg"
         "msg/DetectionInterface/Types/Sign.msg"
+        "msg/DetectionInterface/DetectionInterfaceList.msg"
         "msg/ExtrinsicCalib.msg"
         "msg/HardwareIn.msg"
         "msg/ILQRTrajectory/ILQRTrajectory.msg"

--- a/msg/DetectionInterface/DetectionInterfaceList.msg
+++ b/msg/DetectionInterface/DetectionInterfaceList.msg
@@ -1,0 +1,8 @@
+BarredArea[] barred_areas
+FloorSign[] floor_signs
+IntersectionPoint[] intersection_points
+Obstacle[] obstacles
+ParkSpot[] park_spots
+Pedestrian[] pedestrians
+PedIsle[] ped_isles
+Sign[] signs


### PR DESCRIPTION
Eigener Typ der direkt zu/von `std::vector<std::shared_ptr<const detection::Detection>>`  (aktuell verwendeter Typ) konvertiert werden kann