### PR TITLE
feat(trajectory): Extend lane mode StayOnLeftLane

### DIFF
--- a/msg/TrajectoryPlanningSection.msg
+++ b/msg/TrajectoryPlanningSection.msg
@@ -4,6 +4,7 @@
 int8 MODE_NO_LANE=1
 int8 MODE_STAY_ON_LANE=2
 int8 MODE_STAY_ON_RIGHT_LANE=3
+int8 MODE_STAY_ON_LEFT_LANE=4
 
 # driving mode (abbreviated as 'dm')
 int8 DM_NORMAL=1


### PR DESCRIPTION
Extends the lane mode of `TrajectoryPlanningSection` to include a mode to stay on the left lane.