### PR TITLE
declare builtin_interfaces dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ endif ()
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(std_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
         "msg/AbstractionInterface/AbstractionInterfaceList.msg"
@@ -65,7 +67,10 @@ rosidl_generate_interfaces(${PROJECT_NAME}
         "msg/spatz11/FourWheelDouble.msg"
         "msg/spatz11/IndicatorCommand.msg"
         "msg/spatz11/Spatz11SensorData.msg"
-        DEPENDENCIES geometry_msgs
+        DEPENDENCIES
+        geometry_msgs
+        builtin_interfaces
+        std_msgs
         )
 
 ament_package()

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
 
     <depend>geometry_msgs</depend>
     <depend>std_msgs</depend>
+    <depend>builtin_interfaces</depend>
 
     <exec_depend>rosidl_default_runtime</exec_depend>
 


### PR DESCRIPTION
this dependency was missing, and is used here https://github.com/teamspatzenhirn/spatz_interfaces/blob/master/msg/TrajectoryState.msg#LL1 and here https://github.com/teamspatzenhirn/spatz_interfaces/blob/master/msg/ExtrinsicCalib.msg#L1

otherwise, this does not build on rolling (and probably iron)